### PR TITLE
can not parse header错误显示

### DIFF
--- a/shadowsocks/tcprelay.py
+++ b/shadowsocks/tcprelay.py
@@ -257,7 +257,7 @@ class TCPRelayHandler(object):
                     return
             header_result = parse_header(data)
             if header_result is None:
-                raise Exception('can not parse header')
+                raise Exception('[%s]can not parse header' % (self._config['server_port']))
             addrtype, remote_addr, remote_port, header_length = header_result
             logging.info('connecting %s:%d' % (remote_addr, remote_port))
             self._remote_address = (remote_addr, remote_port)


### PR DESCRIPTION
can not parse header这个错误的显示添加端口号，在翻日志的时候常常看到好多can not parse
header，但是并不知道是哪个ID或者port出了问题，所以顺手加了一个提示，顺便提交上来